### PR TITLE
Limit CI to Ubuntu only

### DIFF
--- a/.github/workflows/conda-package-build.yml
+++ b/.github/workflows/conda-package-build.yml
@@ -14,8 +14,8 @@ jobs:
       fail-fast: false
       max-parallel: 3
       matrix:
-        os: [ ubuntu-latest , macos-latest , windows-latest]
-        python-minor-version: [7 ]
+        os: [ ubuntu-latest ]
+        python-minor-version: [7]
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
The package do not epends on a specific architecture.
Just build it on Ubuntu